### PR TITLE
Jc/dst yaml upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@
 
 FROM cm2network/steamcmd:root
 
+ENV HOMEDIR /home/steam
 ENV STEAMAPPID 343050
 ENV STEAMAPP dst
 ENV STEAMAPPDIR "${HOMEDIR}/${STEAMAPP}-dedicated"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  dst-server:
+    image: catoverflow/dst-server:latest
+    ports:
+      - 10999:10999/udp
+      - 11000:11000/udp
+    volumes:
+      - /home/MyDediServer:/home/steam/.klei/DoNotStarveTogether/MyDediServer

--- a/entry.sh
+++ b/entry.sh
@@ -12,6 +12,11 @@ bash "${STEAMCMDDIR}/steamcmd.sh" \
 
 # launch master and cave server
 cd ${STEAMAPP}-dedicated/bin
-# in case the server exits keeps the tmux window open
-tmux new-session -d -s DST-dedicated -n Master "./dontstarve_dedicated_server_nullrenderer -console -cluster MyDediServer -shard Master; bash -i"
-tmux new-window -d -n Cave -t DST-dedicated: "./dontstarve_dedicated_server_nullrenderer -console -cluster MyDediServer -shard Caves; bash -i"
+
+./dontstarve_dedicated_server_nullrenderer -console -cluster MyDediServer -shard Master &
+
+./dontstarve_dedicated_server_nullrenderer -console -cluster MyDediServer -shard Caves &
+
+wait -n
+
+exit $?

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,13 @@ docker attach dst-dedicated
 # then use ^C-b + [0|1] to switch between Master and Cave tmux windows, ^C-p + q to detach from container
 ~~~~
 
+## Docker Build instructions
+Image can be built using regular docker build commands, however, If you are on an ARM machine (Apple Silicon or other) you will need to use buildx. The following command is an example of how to build the image using buildx on an ARM device for amd 64. And ofc, after building, you'll need to tag your image for push. Enjoy.
+
+~~~~shell
+docker buildx build . --load --platform linux/amd64
+~~~~
+
 ## Known Issues
 
 - Mapping different ports for cave server will make it unusable. Once you enter the cave you will be locked out, as the master server keeps redirecting you to inaccessible cave server port outside the container.

--- a/readme.md
+++ b/readme.md
@@ -29,13 +29,16 @@ docker run \
     -it catoverflow/dst-server
 ~~~~
 
+An example docker compose yaml file is also included.
+
 ### Modding
 
 Follow the instructions in container at `/home/steam/dst-dedicated/mods/dedicated_server_mods_setup.lua`
 
 For mod settings, you can configure them in DST GUI and ship the settings at `~/.klel/DoNotStarveTogether/MyDediServer/[Master|Cave]/modoverrides.lua`
 
-## Manage DST CLI
+## DEPRECATED - Tmux is not recommended as this method forces you to -it in to the container and also prevent docker compose yamls from being used. Only left here for reference.
+## Manage DST CLI 
 
 [Tmux](https://www.redhat.com/sysadmin/introduction-tmux-linux) is used in multi-process management. A `DST-dedicated` session is created with window `Master` and `Cave` responsible for Master (main world) and Cave server.
 


### PR DESCRIPTION
This modification does away with Tmux so that you can run this container using a yaml. This PR would require a rebuild of the image favoring the use of yaml to deploy container enabling support of common container orchestration such as portainer and other docker management tools.